### PR TITLE
Refactor NewValue and support type definitions of basic types

### DIFF
--- a/document/array.go
+++ b/document/array.go
@@ -143,11 +143,11 @@ func (s sliceArray) Iterate(fn func(i int, v Value) error) error {
 	for i := 0; i < l; i++ {
 		f := s.ref.Index(i)
 
-		v, err := reflectValueToValue(f)
-		if err == errUnsupportedType {
-			continue
-		}
+		v, err := NewValue(f.Interface())
 		if err != nil {
+			if err.(*ErrUnsupportedType) != nil {
+				continue
+			}
 			return err
 		}
 
@@ -170,5 +170,5 @@ func (s sliceArray) GetByIndex(i int) (Value, error) {
 		return Value{}, ErrFieldNotFound
 	}
 
-	return reflectValueToValue(v)
+	return NewValue(v.Interface())
 }

--- a/document/scan.go
+++ b/document/scan.go
@@ -26,7 +26,7 @@ func Scan(d Document, targets ...interface{}) error {
 
 		ref := reflect.ValueOf(target)
 		if !ref.IsValid() {
-			return fmt.Errorf("unsupported type %T", target)
+			return &ErrUnsupportedType{target}
 		}
 
 		return scanValue(v, ref)
@@ -182,7 +182,7 @@ func sliceScan(a Array, ref reflect.Value) error {
 func MapScan(d Document, t interface{}) error {
 	ref := reflect.ValueOf(t)
 	if !ref.IsValid() {
-		return fmt.Errorf("unsupported type %s", ref.Type().String())
+		return &ErrUnsupportedType{ref}
 	}
 
 	if ref.Kind() == reflect.Ptr {
@@ -190,7 +190,7 @@ func MapScan(d Document, t interface{}) error {
 	}
 
 	if ref.Kind() != reflect.Map {
-		return fmt.Errorf("unsupported type %s", ref.Type().String())
+		return &ErrUnsupportedType{ref}
 	}
 
 	return mapScan(d, ref)
@@ -198,7 +198,7 @@ func MapScan(d Document, t interface{}) error {
 
 func mapScan(d Document, ref reflect.Value) error {
 	if ref.Type().Key().Kind() != reflect.String {
-		return fmt.Errorf("unsupported type %s", ref.Type().String())
+		return &ErrUnsupportedType{ref}
 	}
 
 	if ref.IsNil() {
@@ -225,7 +225,7 @@ func ScanValue(v Value, t interface{}) error {
 
 func scanValue(v Value, ref reflect.Value) error {
 	if !ref.IsValid() {
-		return fmt.Errorf("unsupported type %s", ref.Type().String())
+		return &ErrUnsupportedType{ref}
 	}
 
 	if ref.Type().Kind() == reflect.Ptr && ref.IsNil() {
@@ -319,5 +319,5 @@ func scanValue(v Value, ref reflect.Value) error {
 		return nil
 	}
 
-	return fmt.Errorf("unsupported type %s", ref.Type().String())
+	return &ErrUnsupportedType{ref}
 }

--- a/document/value_test.go
+++ b/document/value_test.go
@@ -42,6 +42,18 @@ func TestNewValue(t *testing.T) {
 		A int
 		B string
 	}
+	type myBytes []byte
+	type myString string
+	type myBool bool
+	type myUint uint
+	type myUint16 uint16
+	type myUint32 uint32
+	type myUint64 uint64
+	type myInt int
+	type myInt8 int8
+	type myInt16 int16
+	type myInt64 int64
+	type myFloat64 float64
 
 	tests := []struct {
 		name            string
@@ -66,6 +78,17 @@ func TestNewValue(t *testing.T) {
 		{"document", document.NewFieldBuffer().Add("a", document.NewIntValue(10)), document.NewFieldBuffer().Add("a", document.NewIntValue(10))},
 		{"array", document.NewValueBuffer(document.NewIntValue(10)), document.NewValueBuffer(document.NewIntValue(10))},
 		{"duration", 10 * time.Nanosecond, 10 * time.Nanosecond},
+		{"bytes", myBytes("bar"), []byte("bar")},
+		{"string", myString("bar"), []byte("bar")},
+		{"myUint", myUint(10), int8(10)},
+		{"myUint16", myUint16(500), int16(500)},
+		{"myUint32", myUint32(90000), int32(90000)},
+		{"myUint64", myUint64(100), int8(100)},
+		{"myInt", myInt(7), int8(7)},
+		{"myInt8", myInt8(3), int8(3)},
+		{"myInt16", myInt16(500), int16(500)},
+		{"myInt64", myInt64(10), int8(10)},
+		{"myFloat64", myFloat64(10.1), float64(10.1)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR does the following:

* Refactor `document.NewValue()` merging it with `reflectValueToValue()` as both were very similar, and `NewValue()` would not recognize simple type definitions, such as `type myString string` as valid, while `reflectValueToValue()` would and created inconsistencies.
* Added an error type to wrap `ErrUnsupportedType` so this can be checked outside explicitly.
* Upgraded tests to check user types are covered. 