### PR TITLE
Fix ordering by numeric values when there is no index

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -135,7 +135,7 @@ func (i *ListIndex) Set(val document.Value, key []byte) error {
 		return err
 	}
 
-	v, err := encodeFieldToIndexValue(val)
+	v, err := EncodeFieldToIndexValue(val)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (i *ListIndex) Set(val document.Value, key []byte) error {
 
 // Delete all the references to the key from the index.
 func (i *ListIndex) Delete(val document.Value, key []byte) error {
-	v, err := encodeFieldToIndexValue(val)
+	v, err := EncodeFieldToIndexValue(val)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (i *ListIndex) AscendGreaterOrEqual(pivot *Pivot, fn func(val document.Valu
 
 	var data []byte
 	if !pivot.empty {
-		data, err = encodeFieldToIndexValue(pivot.Value)
+		data, err = EncodeFieldToIndexValue(pivot.Value)
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ func (i *ListIndex) DescendLessOrEqual(pivot *Pivot, fn func(val document.Value,
 
 	var data []byte
 	if !pivot.empty {
-		data, err = encodeFieldToIndexValue(pivot.Value)
+		data, err = EncodeFieldToIndexValue(pivot.Value)
 		if err != nil {
 			return err
 		}
@@ -315,7 +315,7 @@ type UniqueIndex struct {
 // Set associates a value with exactly one key.
 // If the association already exists, it returns an error.
 func (i *UniqueIndex) Set(val document.Value, key []byte) error {
-	v, err := encodeFieldToIndexValue(val)
+	v, err := EncodeFieldToIndexValue(val)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func (i *UniqueIndex) Set(val document.Value, key []byte) error {
 
 // Delete all the references to the key from the index.
 func (i *UniqueIndex) Delete(val document.Value, key []byte) error {
-	v, err := encodeFieldToIndexValue(val)
+	v, err := EncodeFieldToIndexValue(val)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (i *UniqueIndex) AscendGreaterOrEqual(pivot *Pivot, fn func(val document.Va
 
 	var data []byte
 	if !pivot.empty {
-		data, err = encodeFieldToIndexValue(pivot.Value)
+		data, err = EncodeFieldToIndexValue(pivot.Value)
 		if err != nil {
 			return err
 		}
@@ -464,7 +464,7 @@ func (i *UniqueIndex) DescendLessOrEqual(pivot *Pivot, fn func(val document.Valu
 
 	var data []byte
 	if !pivot.empty {
-		data, err = encodeFieldToIndexValue(pivot.Value)
+		data, err = EncodeFieldToIndexValue(pivot.Value)
 		if err != nil {
 			return err
 		}
@@ -501,7 +501,9 @@ func (i *UniqueIndex) Truncate() error {
 	return dropStore(i.tx, Bool, i.name)
 }
 
-func encodeFieldToIndexValue(val document.Value) ([]byte, error) {
+// EncodeFieldToIndexValue returns a byte array that represents the value in such
+// a way that can be compared for ordering and indexing
+func EncodeFieldToIndexValue(val document.Value) ([]byte, error) {
 	if val.V != nil && val.Type.IsNumber() && val.Type != document.Float64Value {
 		x, err := val.ConvertToFloat64()
 		if err != nil {

--- a/sql/query/plan.go
+++ b/sql/query/plan.go
@@ -517,7 +517,7 @@ func (qo *queryOptimizer) sortIterator(it document.Iterator) (st document.Stream
 			v = document.NewNullValue()
 		}
 
-		value, err := encoding.EncodeValue(v)
+		value, err := index.EncodeFieldToIndexValue(v)
 		if err != nil {
 			return err
 		}

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -28,45 +28,47 @@ func TestSelectStmt(t *testing.T) {
 		{"No table, function", "SELECT pk()", true, ``, nil},
 		{"No table, function", "SELECT a", false, `[{"a": null}]`, nil},
 		{"No table, function", "SELECT *", true, ``, nil},
-		{"No cond", "SELECT * FROM test", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
-		{"Multiple wildcards cond", "SELECT *, *, color FROM test", false, `[{"k":1,"color":"red","size":10,"shape":"square","k":1,"color":"red","size":10,"shape":"square","color":"red"},{"k":2,"color":"blue","size":10,"weight":1,"k":2,"color":"blue","size":10,"weight":1,"color":"blue"},{"k":3,"height":100,"weight":20,"k":3,"height":100,"weight":20,"color":null}]`, nil},
+		{"No cond", "SELECT * FROM test", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
+		{"Multiple wildcards cond", "SELECT *, *, color FROM test", false, `[{"k":1,"color":"red","size":10,"shape":"square","k":1,"color":"red","size":10,"shape":"square","color":"red"},{"k":2,"color":"blue","size":10,"weight":100,"k":2,"color":"blue","size":10,"weight":100,"color":"blue"},{"k":3,"height":100,"weight":200,"k":3,"height":100,"weight":200,"color":null}]`, nil},
 		{"With fields", "SELECT color, shape FROM test", false, `[{"color":"red","shape":"square"},{"color":"blue","shape":null},{"color":null,"shape":null}]`, nil},
 		{"With expr fields", "SELECT color, color != 'red' AS notred FROM test", false, `[{"color":"red","notred":false},{"color":"blue","notred":true},{"color":null,"notred":true}]`, nil},
-		{"With eq op", "SELECT * FROM test WHERE size = 10", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With neq op", "SELECT * FROM test WHERE color != 'red'", false, `[{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
+		{"With eq op", "SELECT * FROM test WHERE size = 10", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With neq op", "SELECT * FROM test WHERE color != 'red'", false, `[{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
 		{"With gt op", "SELECT * FROM test WHERE size > 10", false, `[]`, nil},
-		{"With lt op", "SELECT * FROM test WHERE size < 15", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With lte op", "SELECT * FROM test WHERE color <= 'salmon' ORDER BY k ASC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
+		{"With lt op", "SELECT * FROM test WHERE size < 15", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With lte op", "SELECT * FROM test WHERE color <= 'salmon' ORDER BY k ASC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
 		{"With add op", "SELECT size + 10 AS s FROM test ORDER BY k", false, `[{"s":20},{"s":20},{"s":null}]`, nil},
 		{"With sub op", "SELECT size - 10 AS s FROM test ORDER BY k", false, `[{"s":0},{"s":0},{"s":null}]`, nil},
 		{"With mul op", "SELECT size * 10 AS s FROM test ORDER BY k", false, `[{"s":100},{"s":100},{"s":null}]`, nil},
 		{"With div op", "SELECT size / 10 AS s FROM test ORDER BY k", false, `[{"s":1},{"s":1},{"s":null}]`, nil},
 		{"With field comparison", "SELECT * FROM test WHERE color < shape", false, `[{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
-		{"With order by", "SELECT * FROM test ORDER BY color", false, `[{"k":3,"height":100,"weight":20},{"k":2,"color":"blue","size":10,"weight":1},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
-		{"With order by asc", "SELECT * FROM test ORDER BY color ASC", false, `[{"k":3,"height":100,"weight":20},{"k":2,"color":"blue","size":10,"weight":1},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
-		{"With order by asc with limit 2", "SELECT * FROM test ORDER BY color LIMIT 2", false, `[{"k":3,"height":100,"weight":20},{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With order by asc with limit 1", "SELECT * FROM test ORDER BY color LIMIT 1", false, `[{"k":3,"height":100,"weight":20}]`, nil},
-		{"With order by asc with offset", "SELECT * FROM test ORDER BY color OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":1},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
-		{"With order by asc with limit offset", "SELECT * FROM test ORDER BY color LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With order by desc", "SELECT * FROM test ORDER BY color DESC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
-		{"With order by desc with limit", "SELECT * FROM test ORDER BY color DESC LIMIT 2", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With order by desc with offset", "SELECT * FROM test ORDER BY color DESC OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
-		{"With order by desc with limit offset", "SELECT * FROM test ORDER BY color DESC LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":1}]`, nil},
-		{"With order by pk asc", "SELECT * FROM test ORDER BY k ASC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
-		{"With order by pk desc", "SELECT * FROM test ORDER BY k DESC", false, `[{"k":3,"height":100,"weight":20},{"k":2,"color":"blue","size":10,"weight":1},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
+		{"With order by", "SELECT * FROM test ORDER BY color", false, `[{"k":3,"height":100,"weight":200},{"k":2,"color":"blue","size":10,"weight":100},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
+		{"With order by asc", "SELECT * FROM test ORDER BY color ASC", false, `[{"k":3,"height":100,"weight":200},{"k":2,"color":"blue","size":10,"weight":100},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
+		{"With order by asc numeric", "SELECT * FROM test ORDER BY weight ASC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
+		{"With order by asc with limit 2", "SELECT * FROM test ORDER BY color LIMIT 2", false, `[{"k":3,"height":100,"weight":200},{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With order by asc with limit 1", "SELECT * FROM test ORDER BY color LIMIT 1", false, `[{"k":3,"height":100,"weight":200}]`, nil},
+		{"With order by asc with offset", "SELECT * FROM test ORDER BY color OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":100},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
+		{"With order by asc with limit offset", "SELECT * FROM test ORDER BY color LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With order by desc", "SELECT * FROM test ORDER BY color DESC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
+		{"With order by desc numeric", "SELECT * FROM test ORDER BY weight DESC", false, `[{"k":3,"height":100,"weight":200},{"k":2,"color":"blue","size":10,"weight":100},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
+		{"With order by desc with limit", "SELECT * FROM test ORDER BY color DESC LIMIT 2", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With order by desc with offset", "SELECT * FROM test ORDER BY color DESC OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
+		{"With order by desc with limit offset", "SELECT * FROM test ORDER BY color DESC LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":100}]`, nil},
+		{"With order by pk asc", "SELECT * FROM test ORDER BY k ASC", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
+		{"With order by pk desc", "SELECT * FROM test ORDER BY k DESC", false, `[{"k":3,"height":100,"weight":200},{"k":2,"color":"blue","size":10,"weight":100},{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
 		{"With order by and where", "SELECT * FROM test WHERE color != 'blue' ORDER BY color DESC LIMIT 1", false, `[{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
 		{"With limit", "SELECT * FROM test WHERE size = 10 LIMIT 1", false, `[{"k":1,"color":"red","size":10,"shape":"square"}]`, nil},
-		{"With offset", "SELECT *, pk() FROM test WHERE size = 10 OFFSET 1", false, `[{"pk()":2,"color":"blue","size":10,"weight":1,"k":2}]`, nil},
-		{"With limit then offset", "SELECT * FROM test WHERE size = 10 LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":1,"k":2}]`, nil},
+		{"With offset", "SELECT *, pk() FROM test WHERE size = 10 OFFSET 1", false, `[{"pk()":2,"color":"blue","size":10,"weight":100,"k":2}]`, nil},
+		{"With limit then offset", "SELECT * FROM test WHERE size = 10 LIMIT 1 OFFSET 1", false, `[{"k":2,"color":"blue","size":10,"weight":100,"k":2}]`, nil},
 		{"With offset then limit", "SELECT * FROM test WHERE size = 10 OFFSET 1 LIMIT 1", true, "", nil},
-		{"With positional params", "SELECT * FROM test WHERE color = ? OR height = ?", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":3,"height":100,"weight":20}]`, []interface{}{"red", 100}},
-		{"With named params", "SELECT * FROM test WHERE color = $a OR height = $d", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":3,"height":100,"weight":20}]`, []interface{}{sql.Named("a", "red"), sql.Named("d", 100)}},
+		{"With positional params", "SELECT * FROM test WHERE color = ? OR height = ?", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":3,"height":100,"weight":200}]`, []interface{}{"red", 100}},
+		{"With named params", "SELECT * FROM test WHERE color = $a OR height = $d", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":3,"height":100,"weight":200}]`, []interface{}{sql.Named("a", "red"), sql.Named("d", 100)}},
 		{"With pk()", "SELECT pk(), color FROM test", false, `[{"pk()":1,"color":"red"},{"pk()":2,"color":"blue"},{"pk()":3,"color":null}]`, []interface{}{sql.Named("a", "red"), sql.Named("d", 100)}},
-		{"With pk in cond, gt", "SELECT * FROM test WHERE k > 0 AND weight = 1", false, `[{"k":2,"color":"blue","size":10,"weight":1,"k":2}]`, nil},
-		{"With pk in cond, =", "SELECT * FROM test WHERE k = 2.0 AND weight = 1", false, `[{"k":2,"color":"blue","size":10,"weight":1,"k":2}]`, nil},
+		{"With pk in cond, gt", "SELECT * FROM test WHERE k > 0 AND weight = 100", false, `[{"k":2,"color":"blue","size":10,"weight":100,"k":2}]`, nil},
+		{"With pk in cond, =", "SELECT * FROM test WHERE k = 2.0 AND weight = 100", false, `[{"k":2,"color":"blue","size":10,"weight":100,"k":2}]`, nil},
 		{"With two non existing idents, =", "SELECT * FROM test WHERE z = y", false, `[]`, nil},
 		{"With two non existing idents, >", "SELECT * FROM test WHERE z > y", false, `[]`, nil},
-		{"With two non existing idents, !=", "SELECT * FROM test WHERE z != y", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":1},{"k":3,"height":100,"weight":20}]`, nil},
+		{"With two non existing idents, !=", "SELECT * FROM test WHERE z != y", false, `[{"k":1,"color":"red","size":10,"shape":"square"},{"k":2,"color":"blue","size":10,"weight":100},{"k":3,"height":100,"weight":200}]`, nil},
 	}
 
 	for _, test := range tests {
@@ -84,15 +86,16 @@ func TestSelectStmt(t *testing.T) {
 						CREATE INDEX idx_size ON test (size);
 						CREATE INDEX idx_shape ON test (shape);
 						CREATE INDEX idx_height ON test (height);
+						CREATE INDEX idx_weight ON test (weight);
 					`)
 					require.NoError(t, err)
 				}
 
 				err = db.Exec("INSERT INTO test (k, color, size, shape) VALUES (1, 'red', 10, 'square')")
 				require.NoError(t, err)
-				err = db.Exec("INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 1)")
+				err = db.Exec("INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 100)")
 				require.NoError(t, err)
-				err = db.Exec("INSERT INTO test (k, height, weight) VALUES (3, 100, 20)")
+				err = db.Exec("INSERT INTO test (k, height, weight) VALUES (3, 100, 200)")
 				require.NoError(t, err)
 
 				st, err := db.Query(test.query, test.params...)


### PR DESCRIPTION
This PR fixes a tricky bug that happens when running queries with an `ORDER BY` clause in which the field is a numeric value and there is no index for that field.

The bug happens because in `plan.go` in the the wrong byte-encoded representation of the value was used, and that does not tell if a number is bigger or smaller than another one. For example:

`0` is encoded as `[]byte{128}`
`100` is encoded as `[]byte{228}`
`200` is encoded as `[]byte{128, 200}`

Doing a pure byte comparison yields that `100` is greater than `200`, because `[]byte{228}` is considered greater than `[]byte{128, 200}` by `bytes.Compare()`.

To fix the issue, I exported the `index.EncodeFieldToIndexValue()` so the same function is used for generating the index and for ordering when there is no index.

I also changed tests in `select_test.go`, but only to put numeric values that would trigger the bug and to actually test ordering by numeric fields, with and without index; a case that was missing. The old tests passed without touching.


