### PR TITLE
Improve struct scanning

### DIFF
--- a/document/document_test.go
+++ b/document/document_test.go
@@ -196,7 +196,8 @@ func TestNewFromMap(t *testing.T) {
 		"nilField": nil,
 	}
 
-	doc := document.NewFromMap(m)
+	doc, err := document.NewFromMap(m)
+	require.NoError(t, err)
 
 	t.Run("Iterate", func(t *testing.T) {
 		counter := make(map[string]int)
@@ -233,6 +234,15 @@ func TestNewFromMap(t *testing.T) {
 
 		_, err = doc.GetByField("bar")
 		require.Equal(t, document.ErrFieldNotFound, err)
+	})
+
+	t.Run("Invalid types", func(t *testing.T) {
+
+		// test NewFromMap rejects invalid types
+		_, err = document.NewFromMap(8)
+		require.Error(t, err, "Expected document.NewFromMap to return an error if the passed parameter is not a map")
+		_, err = document.NewFromMap(map[int]float64{2: 4.3})
+		require.Error(t, err, "Expected document.NewFromMap to return an error if the passed parameter is not a map with a string key type")
 	})
 }
 

--- a/document/encoding/encoding_test.go
+++ b/document/encoding/encoding_test.go
@@ -38,6 +38,18 @@ func TestDecodeValueFromDocument(t *testing.T) {
 }
 
 func TestEncodeDecode(t *testing.T) {
+	userMapDoc, err := document.NewFromMap(map[string]interface{}{
+		"age":  10,
+		"name": "john",
+	})
+	require.NoError(t, err)
+
+	addressMapDoc, err := document.NewFromMap(map[string]string{
+		"city":    "Ajaccio",
+		"country": "France",
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		d        document.Document
@@ -52,10 +64,7 @@ func TestEncodeDecode(t *testing.T) {
 		},
 		{
 			"Map",
-			document.NewFromMap(map[string]interface{}{
-				"age":  10,
-				"name": "john",
-			}),
+			userMapDoc,
 			`{"age": 10, "name": "john"}`,
 		},
 		{
@@ -63,10 +72,7 @@ func TestEncodeDecode(t *testing.T) {
 			document.NewFieldBuffer().
 				Add("age", document.NewInt64Value(10)).
 				Add("name", document.NewTextValue("john")).
-				Add("address", document.NewDocumentValue(document.NewFromMap(map[string]interface{}{
-					"city":    "Ajaccio",
-					"country": "France",
-				}))),
+				Add("address", document.NewDocumentValue(addressMapDoc)),
 			`{"age": 10, "name": "john", "address": {"city": "Ajaccio", "country": "France"}}`,
 		},
 	}
@@ -84,13 +90,16 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestDecodeDocument(t *testing.T) {
+	mapDoc, err := document.NewFromMap(map[string]string{
+		"city":    "Ajaccio",
+		"country": "France",
+	})
+	require.NoError(t, err)
+
 	doc := document.NewFieldBuffer().
 		Add("age", document.NewInt64Value(10)).
 		Add("name", document.NewTextValue("john")).
-		Add("address", document.NewDocumentValue(document.NewFromMap(map[string]interface{}{
-			"city":    "Ajaccio",
-			"country": "France",
-		})))
+		Add("address", document.NewDocumentValue(mapDoc))
 
 	data, err := EncodeDocument(doc)
 	require.NoError(t, err)
@@ -102,10 +111,7 @@ func TestDecodeDocument(t *testing.T) {
 	v, err = ec.GetByField("address")
 	require.NoError(t, err)
 	var expected, actual bytes.Buffer
-	err = document.ToJSON(&expected, document.NewFieldBuffer().Add("address", document.NewDocumentValue(document.NewFromMap(map[string]interface{}{
-		"city":    "Ajaccio",
-		"country": "France",
-	}))))
+	err = document.ToJSON(&expected, document.NewFieldBuffer().Add("address", document.NewDocumentValue(mapDoc)))
 	require.NoError(t, err)
 	err = document.ToJSON(&actual, document.NewFieldBuffer().Add("address", v))
 	require.NoError(t, err)
@@ -118,10 +124,7 @@ func TestDecodeDocument(t *testing.T) {
 			require.Equal(t, document.NewInt64Value(10), v)
 		case "address":
 			var expected, actual bytes.Buffer
-			err = document.ToJSON(&expected, document.NewFieldBuffer().Add("address", document.NewDocumentValue(document.NewFromMap(map[string]interface{}{
-				"city":    "Ajaccio",
-				"country": "France",
-			}))))
+			err = document.ToJSON(&expected, document.NewFieldBuffer().Add("address", document.NewDocumentValue(mapDoc)))
 			require.NoError(t, err)
 			err = document.ToJSON(&actual, document.NewFieldBuffer().Add(f, v))
 			require.NoError(t, err)
@@ -137,6 +140,12 @@ func TestDecodeDocument(t *testing.T) {
 }
 
 func TestEncodeArray(t *testing.T) {
+	mapDoc, err := document.NewFromMap(map[string]string{
+		"city":    "Ajaccio",
+		"country": "France",
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		a        document.Array
@@ -147,10 +156,7 @@ func TestEncodeArray(t *testing.T) {
 			document.NewValueBuffer().
 				Append(document.NewInt64Value(10)).
 				Append(document.NewTextValue("john")).
-				Append(document.NewDocumentValue(document.NewFromMap(map[string]interface{}{
-					"city":    "Ajaccio",
-					"country": "France",
-				}))).
+				Append(document.NewDocumentValue(mapDoc)).
 				Append(document.NewArrayValue(document.NewValueBuffer().Append(document.NewInt64Value(11)))),
 			`[10, "john", {"city": "Ajaccio", "country": "France"}, [11]]`,
 		},

--- a/document/scan.go
+++ b/document/scan.go
@@ -26,7 +26,7 @@ func Scan(d Document, targets ...interface{}) error {
 
 		ref := reflect.ValueOf(target)
 		if !ref.IsValid() {
-			return &ErrUnsupportedType{target}
+			return &ErrUnsupportedType{target, fmt.Sprintf("Parameter %d is not valid", i)}
 		}
 
 		return scanValue(v, ref)
@@ -85,12 +85,7 @@ func structScan(d Document, ref reflect.Value) error {
 			return err
 		}
 
-		if f.Type().Kind() == reflect.Ptr {
-			err = scanValue(v, f)
-		} else {
-			err = scanValue(v, f)
-		}
-		if err != nil {
+		if err := scanValue(v, f); err != nil {
 			return err
 		}
 	}
@@ -182,7 +177,7 @@ func sliceScan(a Array, ref reflect.Value) error {
 func MapScan(d Document, t interface{}) error {
 	ref := reflect.ValueOf(t)
 	if !ref.IsValid() {
-		return &ErrUnsupportedType{ref}
+		return &ErrUnsupportedType{ref, "t must be a valid reference"}
 	}
 
 	if ref.Kind() == reflect.Ptr {
@@ -190,7 +185,7 @@ func MapScan(d Document, t interface{}) error {
 	}
 
 	if ref.Kind() != reflect.Map {
-		return &ErrUnsupportedType{ref}
+		return &ErrUnsupportedType{ref, "t is not a map"}
 	}
 
 	return mapScan(d, ref)
@@ -198,7 +193,7 @@ func MapScan(d Document, t interface{}) error {
 
 func mapScan(d Document, ref reflect.Value) error {
 	if ref.Type().Key().Kind() != reflect.String {
-		return &ErrUnsupportedType{ref}
+		return &ErrUnsupportedType{ref, "map key must be a string"}
 	}
 
 	if ref.IsNil() {
@@ -225,7 +220,7 @@ func ScanValue(v Value, t interface{}) error {
 
 func scanValue(v Value, ref reflect.Value) error {
 	if !ref.IsValid() {
-		return &ErrUnsupportedType{ref}
+		return &ErrUnsupportedType{ref, "parameter is not a valid reference"}
 	}
 
 	if ref.Type().Kind() == reflect.Ptr && ref.IsNil() {
@@ -319,5 +314,5 @@ func scanValue(v Value, ref reflect.Value) error {
 		return nil
 	}
 
-	return &ErrUnsupportedType{ref}
+	return &ErrUnsupportedType{ref, "Invalid type"}
 }

--- a/document/value.go
+++ b/document/value.go
@@ -27,10 +27,11 @@ var (
 // this error is used to skip struct or array fields that are not supported.
 type ErrUnsupportedType struct {
 	Value interface{}
+	Msg   string
 }
 
 func (e *ErrUnsupportedType) Error() string {
-	return fmt.Sprintf("unsupported type %T", e.Value)
+	return fmt.Sprintf("unsupported type %T. %s", e.Value, e.Msg)
 }
 
 // ValueType represents a value type supported by the database.
@@ -164,10 +165,16 @@ func NewValue(x interface{}) (Value, error) {
 			return NewNullValue(), nil
 		}
 		return NewArrayValue(&sliceArray{ref: v}), nil
+	case reflect.Map:
+		doc, err := NewFromMap(x)
+		if err != nil {
+			return Value{}, err
+		}
+		return NewDocumentValue(doc), nil
 
 	}
 
-	return Value{}, &ErrUnsupportedType{x}
+	return Value{}, &ErrUnsupportedType{x, ""}
 }
 
 // NewBlobValue encodes x and returns a value.


### PR DESCRIPTION
This PR does the following:
* Enables embedded struct fields in `document.NewFromStruct()` so they are considered rather than ignored. 
* Enable any map type with string key in `document.NewFromMap()`. This allows users to pass any kind of map with a string key instead of just `map[string]interface{}`
* Better error messages for `document.ErrUnsupportedType` errors.
