### PR TITLE
[Genji/shell] Assert that the error holds the concrete ParseError type

### DIFF
--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -294,7 +294,11 @@ func (sh *Shell) changelivePrefix() (string, bool) {
 func completer(in prompt.Document) []prompt.Suggest {
 	_, err := parser.NewParser(strings.NewReader(in.Text)).ParseQuery()
 	if err != nil {
-		expected := err.(*parser.ParseError).Expected
+		e, ok := err.(*parser.ParseError)
+		if !ok {
+			return []prompt.Suggest{}
+		}
+		expected := e.Expected
 		suggestions := make([]prompt.Suggest, len(expected))
 		for i, e := range expected {
 			suggestions[i].Text = e


### PR DESCRIPTION
This is a potential fix for #67.

Actually, if a function is not yet supported, an error will be returned from the `query` package. This error is not a `ParseError` which makes the shell panic.
From now on, we assert that the error holds the concrete `ParseError` type, if not, we just return an empty slice of suggestions.