### PR TITLE
Simple cli tool fixes 

### DIFF
--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -17,11 +17,11 @@ func main() {
 	app.Version = "v0.4.0"
 	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "bolt",
 			Usage: "use bolt engine",
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "badger",
 			Usage: "use badger engine",
 		},

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -217,6 +217,8 @@ func (sh *Shell) runCommand(cmd string) error {
 			return err
 		}
 		return runTablesCmd(db)
+	case ".exit":
+		os.Exit(0)
 	}
 
 	return fmt.Errorf("unknown command %q", cmd)


### PR DESCRIPTION
This pull-request fixes a couple of issues I had when working with the genji cli tool.
I ran into a compile error at first, because of a mismatched type between the cli.Flag interface and the cli.BoolFlag type. Correcting that was simple and allowed the app to compile after making the change.

When working with the cli tool, I was expecting to find a way to exit or quit the cli from the interactive prompt like in other database cli tools. Having not found a method to quit the application from the prompt, I added the `.exit` command to give an easy way to quit the app.