### PR TITLE
Add package reference to the error returned in the godoc

### DIFF
--- a/db.go
+++ b/db.go
@@ -95,7 +95,7 @@ func (db *DB) Query(q string, args ...interface{}) (*query.Result, error) {
 }
 
 // QueryDocument runs the query and returns the first document.
-// If the query returns no error, QueryDocument returns ErrDocumentNotFound.
+// If the query returns no error, QueryDocument returns database.ErrDocumentNotFound.
 func (db *DB) QueryDocument(q string, args ...interface{}) (document.Document, error) {
 	res, err := db.Query(q, args...)
 	if err != nil {
@@ -168,7 +168,7 @@ func (tx *Tx) Query(q string, args ...interface{}) (*query.Result, error) {
 }
 
 // QueryDocument runs the query and returns the first document.
-// If the query returns no error, QueryDocument returns ErrDocumentNotFound.
+// If the query returns no error, QueryDocument returns database.ErrDocumentNotFound.
 func (tx *Tx) QueryDocument(q string, args ...interface{}) (document.Document, error) {
 	res, err := tx.Query(q, args...)
 	if err != nil {


### PR DESCRIPTION
Since that the `ErrDocumentNotFound` error returned from `QueryDocument` is in a different package, I think it's better to add a reference to this package in the godoc.
I had to look for it in the code to see where it is declared, probably more straightforward now.