### PR TITLE
Add support for UNSET clause

### DIFF
--- a/database/table.go
+++ b/database/table.go
@@ -133,11 +133,11 @@ func getParentValue(d document.Document, p document.ValuePath) (document.Value, 
 	return p[:len(p)-1].GetValue(d)
 }
 
-// validateConstraints check the table configuration for constraints and validates the document
+// ValidateConstraints check the table configuration for constraints and validates the document
 // against them. If the types defined by the constraints are different than the ones found in
 // the document, the fields are converted to these types when possible. if the conversion
 // fails, an error is returned.
-func (t *Table) validateConstraints(d document.Document) (document.Document, error) {
+func (t *Table) ValidateConstraints(d document.Document) (document.Document, error) {
 	cfg, err := t.Config()
 	if err != nil {
 		return nil, err
@@ -274,7 +274,7 @@ func validateConstraint(d document.Document, c *FieldConstraint) error {
 // in the given document.
 // If no primary key has been selected, a monotonic autoincremented integer key will be generated.
 func (t *Table) Insert(d document.Document) ([]byte, error) {
-	d, err := t.validateConstraints(d)
+	d, err := t.ValidateConstraints(d)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/parser/update.go
+++ b/sql/parser/update.go
@@ -22,9 +22,9 @@ func (p *Parser) parseUpdateStatement() (query.UpdateStmt, error) {
 	tok, pos, lit := p.ScanIgnoreWhitespace()
 	switch tok {
 	case scanner.SET:
-		stmt.Pairs, err = p.parseSetClause()
+		stmt.SetPairs, err = p.parseSetClause()
 	case scanner.UNSET:
-		stmt.Fields, err = p.parseUnsetClause()
+		stmt.UnsetFields, err = p.parseUnsetClause()
 	default:
 		err = newParseError(scanner.Tokstr(tok, lit), []string{"SET", "UNSET"}, pos)
 	}

--- a/sql/parser/update_test.go
+++ b/sql/parser/update_test.go
@@ -15,7 +15,7 @@ func TestParserUdpate(t *testing.T) {
 		expected query.Statement
 		errored  bool
 	}{
-		{"No cond", "UPDATE test SET a = 1",
+		{"SET/No cond", "UPDATE test SET a = 1",
 			query.UpdateStmt{
 				TableName: "test",
 				Pairs: map[string]expr.Expr{
@@ -23,13 +23,26 @@ func TestParserUdpate(t *testing.T) {
 				},
 			},
 			false},
-		{"With cond", "UPDATE test SET a = 1, b = 2 WHERE age = 10",
+		{"SET/With cond", "UPDATE test SET a = 1, b = 2 WHERE age = 10",
 			query.UpdateStmt{
 				TableName: "test",
 				Pairs: map[string]expr.Expr{
 					"a": expr.IntValue(1),
 					"b": expr.IntValue(2),
 				},
+				WhereExpr: expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntValue(10)),
+			},
+			false},
+		{"UNSET/No cond", "UPDATE test UNSET a",
+			query.UpdateStmt{
+				TableName: "test",
+				Fields:    []string{"a"},
+			},
+			false},
+		{"UNSET/With cond", "UPDATE test UNSET a, b WHERE age = 10",
+			query.UpdateStmt{
+				TableName: "test",
+				Fields:    []string{"a", "b"},
 				WhereExpr: expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntValue(10)),
 			},
 			false},

--- a/sql/parser/update_test.go
+++ b/sql/parser/update_test.go
@@ -18,7 +18,7 @@ func TestParserUdpate(t *testing.T) {
 		{"SET/No cond", "UPDATE test SET a = 1",
 			query.UpdateStmt{
 				TableName: "test",
-				Pairs: map[string]expr.Expr{
+				SetPairs: map[string]expr.Expr{
 					"a": expr.IntValue(1),
 				},
 			},
@@ -26,7 +26,7 @@ func TestParserUdpate(t *testing.T) {
 		{"SET/With cond", "UPDATE test SET a = 1, b = 2 WHERE age = 10",
 			query.UpdateStmt{
 				TableName: "test",
-				Pairs: map[string]expr.Expr{
+				SetPairs: map[string]expr.Expr{
 					"a": expr.IntValue(1),
 					"b": expr.IntValue(2),
 				},
@@ -35,15 +35,15 @@ func TestParserUdpate(t *testing.T) {
 			false},
 		{"UNSET/No cond", "UPDATE test UNSET a",
 			query.UpdateStmt{
-				TableName: "test",
-				Fields:    []string{"a"},
+				TableName:   "test",
+				UnsetFields: []string{"a"},
 			},
 			false},
 		{"UNSET/With cond", "UPDATE test UNSET a, b WHERE age = 10",
 			query.UpdateStmt{
-				TableName: "test",
-				Fields:    []string{"a", "b"},
-				WhereExpr: expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntValue(10)),
+				TableName:   "test",
+				UnsetFields: []string{"a", "b"},
+				WhereExpr:   expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntValue(10)),
 			},
 			false},
 		{"Trailing comma", "UPDATE test SET a = 1, WHERE age = 10", nil, true},

--- a/sql/query/update.go
+++ b/sql/query/update.go
@@ -16,7 +16,16 @@ const updateBufferSize = 100
 // UpdateStmt is a DSL that allows creating a full Update query.
 type UpdateStmt struct {
 	TableName string
-	Pairs     map[string]expr.Expr
+
+	// Pairs is used along with the Set clause. It holds
+	// each field with its corresponding value that
+	// should be set in the document.
+	Pairs map[string]expr.Expr
+
+	// Fields is used along with the Unset clause. It holds
+	// each field that should be unset from the document.
+	Fields []string
+
 	WhereExpr expr.Expr
 }
 

--- a/sql/query/update.go
+++ b/sql/query/update.go
@@ -157,8 +157,6 @@ func (stmt UpdateStmt) unset(d *document.FieldBuffer, t *database.Table) error {
 			continue
 		}
 
-		// The only error eventually returned by Delete is ErrFieldNotFound,
-		// it can be skipped.
 		err = d.Delete(f)
 		if err != nil {
 			return err

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -22,23 +22,23 @@ func TestUpdateStmt(t *testing.T) {
 		{"No clause", `UPDATE test`, true, "", nil},
 
 		// SET tests.
-		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
-		{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
-		{"SET / No cond / with multiple idents", `UPDATE test SET a = c`, false, `[{"a":"baz1","b":"bar1","c":"baz1"},{"a":null,"b":"bar2"},{"a":null,"d":"foo3","e":"bar3"}]`, nil},
-		{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
+		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with multiple idents", `UPDATE test SET a = c`, false, `[{"a":"baz1","b":"bar1","c":"baz1"},{"a":null,"b":"bar2"},{"a":null,"d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
 		{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
-		{"SET / With cond", "UPDATE test SET a = 1, b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":1,"b":2},{"d":"foo3","e":"bar3"}]`, nil},
-		{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'foo3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
-		{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
-		{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{"a", "b", "foo1"}},
-		{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
+		{"SET / With cond", "UPDATE test SET a = 1, b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":1,"b":2},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'bar3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
+		{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{"a", "b", "foo1"}},
+		{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
 
 		// UNSET tests.
-		{"UNSET / No cond", `UPDATE test UNSET a`, false, `[{"b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
-		{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", false, `[{"b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
-		{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"UNSET / No cond", `UPDATE test UNSET b`, false, `[{"a":"foo1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", true, "", nil},
+		{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
 		{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
-		{"UNSET / With cond", `UPDATE test UNSET a WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"UNSET / With cond", `UPDATE test UNSET b WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
 	}
 
 	for _, test := range tests {
@@ -47,13 +47,13 @@ func TestUpdateStmt(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec("CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test (a text not null)")
 			require.NoError(t, err)
 			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
 			require.NoError(t, err)
 			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
 			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (d, e) VALUES ('foo3', 'bar3')")
+			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
 			require.NoError(t, err)
 
 			err = db.Exec(test.query, test.params...)

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -18,16 +18,27 @@ func TestUpdateStmt(t *testing.T) {
 		expected string
 		params   []interface{}
 	}{
-		{"No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
-		{"No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
-		{"No cond / with multiple idents", `UPDATE test SET a = c`, false, `[{"a":"baz1","b":"bar1","c":"baz1"},{"a":null,"b":"bar2"},{"a":null,"d":"foo3","e":"bar3"}]`, nil},
-		{"No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
-		{"No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
-		{"With cond", "UPDATE test SET a = 1, b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":1,"b":2},{"d":"foo3","e":"bar3"}]`, nil},
-		{"With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'foo3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
-		{"Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
-		{"Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{"a", "b", "foo1"}},
-		{"Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
+		// Test without any clause.
+		{"No clause", `UPDATE test`, true, "", nil},
+
+		// SET tests.
+		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
+		{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"foo3","e":"bar3"}]`, nil},
+		{"SET / No cond / with multiple idents", `UPDATE test SET a = c`, false, `[{"a":"baz1","b":"bar1","c":"baz1"},{"a":null,"b":"bar2"},{"a":null,"d":"foo3","e":"bar3"}]`, nil},
+		{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
+		{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
+		{"SET / With cond", "UPDATE test SET a = 1, b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":1,"b":2},{"d":"foo3","e":"bar3"}]`, nil},
+		{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'foo3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3","f":"boo"}]`, nil},
+		{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{"a", "b", "foo1"}},
+		{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
+
+		// UNSET tests.
+		{"UNSET / No cond", `UPDATE test UNSET a`, false, `[{"b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", false, `[{"b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
+		{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
+		{"UNSET / With cond", `UPDATE test UNSET a WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"b":"bar2"},{"d":"foo3","e":"bar3"}]`, nil},
 	}
 
 	for _, test := range tests {

--- a/sql/scanner/scanner_test.go
+++ b/sql/scanner/scanner_test.go
@@ -142,7 +142,10 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `OFFSET`, tok: scanner.OFFSET, raw: `OFFSET`},
 		{s: `ORDER`, tok: scanner.ORDER, raw: `ORDER`},
 		{s: `SELECT`, tok: scanner.SELECT, raw: `SELECT`},
+		{s: `SET`, tok: scanner.SET, raw: `SET`},
 		{s: `TO`, tok: scanner.TO, raw: `TO`},
+		{s: `UPDATE`, tok: scanner.UPDATE, raw: `UPDATE`},
+		{s: `UNSET`, tok: scanner.UNSET, raw: `UNSET`},
 		{s: `VALUES`, tok: scanner.VALUES, raw: `VALUES`},
 		{s: `WHERE`, tok: scanner.WHERE, raw: `WHERE`},
 		{s: `seLECT`, tok: scanner.SELECT, raw: `seLECT`}, // case insensitive

--- a/sql/scanner/token.go
+++ b/sql/scanner/token.go
@@ -99,6 +99,7 @@ const (
 	TABLE
 	TO
 	UNIQUE
+	UNSET
 	UPDATE
 	VALUES
 	WHERE
@@ -197,6 +198,7 @@ var tokens = [...]string{
 	TABLE:   "TABLE",
 	TO:      "TO",
 	UNIQUE:  "UNIQUE",
+	UNSET:   "UNSET",
 	UPDATE:  "UPDATE",
 	VALUES:  "VALUES",
 	WHERE:   "WHERE",


### PR DESCRIPTION
This PR adds support for `UNSET` clause.

`Table.ValidateConstraints` has been exposed because it's needed for validating the constraints when unsetting a field. 

Tests have been improved along the way as well.
