### PR TITLE
Add support for time.Time

### DIFF
--- a/document/create.go
+++ b/document/create.go
@@ -147,6 +147,8 @@ func NewValue(x interface{}) (Value, error) {
 	switch v := x.(type) {
 	case time.Duration:
 		return NewDurationValue(v), nil
+	case time.Time:
+		return NewTextValue(v.Format(time.RFC3339Nano)), nil
 	case nil:
 		return NewNullValue(), nil
 	case Document:

--- a/document/scan_test.go
+++ b/document/scan_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestScan(t *testing.T) {
+	now := time.Now()
+
 	doc := document.NewFieldBuffer().
 		Add("a", document.NewBlobValue([]byte("foo"))).
 		Add("b", document.NewTextValue("bar")).
@@ -45,7 +47,8 @@ func TestScan(t *testing.T) {
 				Add("foo", document.NewTextValue("foo")).
 				Add("bar", document.NewTextValue("bar")),
 		)).
-		Add("o", document.NewDurationValue(10*time.Nanosecond))
+		Add("o", document.NewDurationValue(10*time.Nanosecond)).
+		Add("p", document.NewTextValue(now.Format(time.RFC3339Nano)))
 
 	type foo struct {
 		Foo string
@@ -68,8 +71,9 @@ func TestScan(t *testing.T) {
 	var m *foo
 	var n map[string]string
 	var o time.Duration
+	var p time.Time
 
-	err := document.Scan(doc, &a, &b, &c, &d, &e, &f, &g, &h, &i, &j, &k, &l, &m, &n, &o)
+	err := document.Scan(doc, &a, &b, &c, &d, &e, &f, &g, &h, &i, &j, &k, &l, &m, &n, &o, &p)
 	require.NoError(t, err)
 	require.Equal(t, a, []byte("foo"))
 	require.Equal(t, b, "bar")
@@ -87,6 +91,7 @@ func TestScan(t *testing.T) {
 	require.Equal(t, &foo{Foo: "foo", Pub: &bar}, m)
 	require.Equal(t, map[string]string{"foo": "foo", "bar": "bar"}, n)
 	require.Equal(t, 10*time.Nanosecond, o)
+	require.Equal(t, now.Format(time.RFC3339Nano), p.Format(time.RFC3339Nano))
 
 	t.Run("DocumentScanner", func(t *testing.T) {
 		var ds documentScanner
@@ -102,14 +107,14 @@ func TestScan(t *testing.T) {
 		m := make(map[string]interface{})
 		err := document.MapScan(doc, m)
 		require.NoError(t, err)
-		require.Len(t, m, 15)
+		require.Len(t, m, 16)
 	})
 
 	t.Run("MapPtr", func(t *testing.T) {
 		var m map[string]interface{}
 		err := document.MapScan(doc, &m)
 		require.NoError(t, err)
-		require.Len(t, m, 15)
+		require.Len(t, m, 16)
 	})
 
 	t.Run("Small Slice", func(t *testing.T) {

--- a/document/value_test.go
+++ b/document/value_test.go
@@ -51,6 +51,8 @@ func TestNewValue(t *testing.T) {
 	type myInt64 int64
 	type myFloat64 float64
 
+	now := time.Now()
+
 	tests := []struct {
 		name            string
 		value, expected interface{}
@@ -73,6 +75,7 @@ func TestNewValue(t *testing.T) {
 		{"document", document.NewFieldBuffer().Add("a", document.NewIntegerValue(10)), document.NewFieldBuffer().Add("a", document.NewIntegerValue(10))},
 		{"array", document.NewValueBuffer(document.NewIntegerValue(10)), document.NewValueBuffer(document.NewIntegerValue(10))},
 		{"duration", 10 * time.Nanosecond, 10 * time.Nanosecond},
+		{"time", now, now.Format(time.RFC3339Nano)},
 		{"bytes", myBytes("bar"), []byte("bar")},
 		{"string", myString("bar"), "bar"},
 		{"myUint", myUint(10), int64(10)},


### PR DESCRIPTION
This PR adds reading and scanning from and to a `time.Time` into a RFC3339Nano `TEXT` value.

Fixes #154 